### PR TITLE
Name of the RPG fligthmare render updated

### DIFF
--- a/flightros/launch/rotors_gazebo.launch
+++ b/flightros/launch/rotors_gazebo.launch
@@ -6,7 +6,7 @@
   <arg name="model" value="$(find rotors_description)/urdf/mav_generic_odometry_sensor.gazebo"/>
   <arg name="world_name" default="$(find rotors_gazebo)/worlds/basic.world"/>
 
-  <arg name="use_unity_editor" default="true" />
+  <arg name="use_unity_editor" default="false" /> <!--changed to false-->
   <arg name="paused" value="true"/>
   <arg name="gui" value="true"/>
   <arg name="use_mpc" default="false"/>
@@ -65,7 +65,9 @@
     </node>
 
     <!-- RPG Flightmare Unity Render. -->
-    <node pkg="flightrender" type="RPG_Flightmare.x86_64" name="rpg_flightmare_render" unless="$(arg use_unity_editor)">
+ <!--   <node pkg="flightrender" type="RPG_Flightmare.x86_64" name="rpg_flightmare_render" unless="$(arg use_unity_editor)">
+    </node>-->
+    <node pkg="flightrender" type="flightmare.x86_64" name="rpg_flightmare_render" unless="$(arg use_unity_editor)"> <!-- name of the flightmare updated-->
     </node>
 
     <!-- Autopilot -->

--- a/flightros/launch/rotors_gazebo_test.launch
+++ b/flightros/launch/rotors_gazebo_test.launch
@@ -5,7 +5,10 @@
       <remap from="flight_pilot/state_estimate" to="ground_truth/odometry" />
     </node>
 
-    <node pkg="flightrender" type="RPG_Flightmare.x86_64" name="rpg_flightmare_render">
-    </node>
+    <node pkg="flightrender" type="flightmare.x86_64" name="rpg_flightmare_render">
+    </node> <!-- name of the flightmare updated -->
+
+    <!--<node pkg="flightrender" type="RPG_Flightmare.x86_64" name="rpg_flightmare_render">
+    </node>-->
 
 </launch>


### PR DESCRIPTION
After extracting the RPG_Flightmare.tar.xz file in the flightrender folder the name of the RPG Flightmare Unity Render becomes flightmare.x86_64 instead of  RPG_Flightmare.x86_64 
