### PR TITLE
Ubuntu 20.04 opencv fix

### DIFF
--- a/flightlib/CMakeLists.txt
+++ b/flightlib/CMakeLists.txt
@@ -48,6 +48,7 @@ include(cmake/yaml.cmake)
 
 # Including dependencies 
 find_package(OpenCV REQUIRED)
+include_directories(${OpenCV_INCLUDE_DIRS})
 find_package(OpenMP REQUIRED)
 
 if(ENABLE_BLAS)

--- a/flightlib/include/flightlib/bridges/unity_bridge.hpp
+++ b/flightlib/include/flightlib/bridges/unity_bridge.hpp
@@ -13,6 +13,8 @@
 #include <string>
 #include <unordered_map>
 
+// opencv
+#include <opencv2/imgproc/types_c.h>
 
 // Include ZMQ bindings for communications with Unity.
 #include <zmqpp/zmqpp.hpp>


### PR DESCRIPTION
Installing via pip on Ubuntu 20.04 causes some errors with OpenCV (as mentioned in #23). This should solve that in a backwards-compatible way. The `include_directories()` for cmake prevents an error that `opencv2/*.hpp` cannot be found (as mentioned [here](https://stackoverflow.com/questions/63455427/fatal-error-opencv2-opencv-modules-hpp-no-such-file-or-directory-include-ope).