### PR TITLE
Fix bug on extra info

### DIFF
--- a/flightlib/src/envs/vec_env.cpp
+++ b/flightlib/src/envs/vec_env.cpp
@@ -152,7 +152,7 @@ void VecEnv<EnvBase>::perAgentStep(int agent_id, Ref<MatrixRowMajor<>> act,
   done(agent_id) = envs_[agent_id]->isTerminalState(terminal_reward);
 
   envs_[agent_id]->updateExtraInfo();
-  for (int j = 0; j < extra_info.size(); j++)
+  for (int j = 0; j < extra_info.cols(); j++)
     extra_info(agent_id, j) =
       envs_[agent_id]->extra_info_[extra_info_names_[j]];
 


### PR DESCRIPTION
When the extra info vector was used it caused a segfault because the for used the size of the whole matrix and not the number of elements of the extra info vector. Quite annoying to debug so can quite useful if anyone will use the extra info in the future