### PR TITLE
Fixed Eigen assertion error, on Ubuntu 20.04 ROS Noetic, also working on Melodic

### DIFF
--- a/docs/source/tutorials_general/racing.cpp
+++ b/docs/source/tutorials_general/racing.cpp
@@ -82,8 +82,8 @@ int main(int argc, char *argv[]) {
   std::size_t num_waypoints = way_points.size();
   Eigen::VectorXd segment_times(num_waypoints);
   segment_times << 10.0, 10.0, 10.0, 10.0;
-  Eigen::VectorXd minimization_weights(num_waypoints);
-  minimization_weights << 1.0, 1.0, 1.0, 1.0;
+  Eigen::VectorXd minimization_weights(5);
+  minimization_weights << 0.0, 1.0, 1.0, 1.0, 1.0;
 
   polynomial_trajectories::PolynomialTrajectorySettings trajectory_settings =
     polynomial_trajectories::PolynomialTrajectorySettings(

--- a/docs/source/tutorials_general/racing.rst
+++ b/docs/source/tutorials_general/racing.rst
@@ -23,8 +23,8 @@ Generate trajectory
   std::size_t num_waypoints = way_points.size();
   Eigen::VectorXd segment_times(num_waypoints);
   segment_times << 10.0, 10.0, 10.0, 10.0;
-  Eigen::VectorXd minimization_weights(num_waypoints);
-  minimization_weights << 1.0, 1.0, 1.0, 1.0;
+  Eigen::VectorXd minimization_weights(5);
+  minimization_weights << 0.0, 1.0, 1.0, 1.0, 1.0;
 
   polynomial_trajectories::PolynomialTrajectorySettings trajectory_settings =
     polynomial_trajectories::PolynomialTrajectorySettings(

--- a/flightros/src/racing/racing.cpp
+++ b/flightros/src/racing/racing.cpp
@@ -69,8 +69,8 @@ int main(int argc, char *argv[]) {
   std::size_t num_waypoints = way_points.size();
   Eigen::VectorXd segment_times(num_waypoints);
   segment_times << 10.0, 10.0, 10.0, 10.0;
-  Eigen::VectorXd minimization_weights(num_waypoints);
-  minimization_weights << 1.0, 1.0, 1.0, 1.0;
+  Eigen::VectorXd minimization_weights(5);
+  minimization_weights << 0.0, 1.0, 1.0, 1.0, 1.0;
 
   polynomial_trajectories::PolynomialTrajectorySettings trajectory_settings =
     polynomial_trajectories::PolynomialTrajectorySettings(


### PR DESCRIPTION
Missing minimisation weight when generating trajectory in racing example, now at 5  (0.0,1.0,1.0,1.0,1.0) and updated in docs, working in Melodic 18.04 and Noetic 20.04.

Haven't compared exact quadrotor path but it looks the same!

Taken from the test code from rpg_quadrotor_control:
https://github.com/uzh-rpg/rpg_quadrotor_control/blob/master/test/rpg_quadrotor_integration_test/src/rpg_quadrotor_integration_test.cpp

 