### PR TITLE
Install packages recursively

### DIFF
--- a/flightrl/setup.py
+++ b/flightrl/setup.py
@@ -17,5 +17,5 @@ setup(
     long_description='',
     install_requires=['gym==0.11', 'ruamel.yaml',
                       'numpy', 'stable_baselines==2.10.1'],
-    packages=['rpg_baselines'],
+    packages=find_packages(),
 )


### PR DESCRIPTION
Solves #85, where packages below `rpg_baselines` are not installed.