### PR TITLE
Clamp with collective thrust

### DIFF
--- a/flightlib/src/dynamics/quadrotor_dynamics.cpp
+++ b/flightlib/src/dynamics/quadrotor_dynamics.cpp
@@ -92,7 +92,7 @@ Vector<4> QuadrotorDynamics::clampThrust(const Vector<4> thrusts) const {
 }
 
 Scalar QuadrotorDynamics::clampThrust(const Scalar thrust) const {
-  return std::clamp(thrust, thrust_min_, thrust_max_);
+  return std::clamp(thrust, collective_thrust_min() / mass_, collective_thrust_max() / mass_);
 }
 
 Vector<4> QuadrotorDynamics::clampMotorOmega(const Vector<4>& omega) const {


### PR DESCRIPTION
The scalar overloading of `clampThrust`, which is only used [here](https://github.com/uzh-rpg/flightmare/blob/170676e4dbc2cdbc1fb7566ab0238800902e3669/flightlib/src/objects/quadrotor.cpp#L138) to clamp the collective thrust, should be using the collective thrust (in m/s2, so divided by mass) as clamping bounds, instead of the per-motor thrust limits.