### PR TITLE
Update the gtest branch to main, fix rpg_baselines refs

### DIFF
--- a/flightlib/cmake/gtest_download.cmake
+++ b/flightlib/cmake/gtest_download.cmake
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           main
   SOURCE_DIR        "${PROJECT_SOURCE_DIR}/externals/googletest-src"
   BINARY_DIR        "${PROJECT_SOURCE_DIR}/externals/googletest-build"
   CONFIGURE_COMMAND ""

--- a/flightrl/setup.py
+++ b/flightrl/setup.py
@@ -17,5 +17,5 @@ setup(
     long_description='',
     install_requires=['gym==0.11', 'ruamel.yaml',
                       'numpy', 'stable_baselines==2.10.1'],
-    packages=['rpg_baselines'],
+    packages=['rpg_baselines','rpg_baselines.ppo','rpg_baselines.common','rpg_baselines.envs'],
 )


### PR DESCRIPTION
Howdy y'all! Fixing a couple of issues I ran into while getting this thing running on a GCP Ubuntu 18.04 instance.

- `googletest` has updated their main branch from `master`, see this [issue](https://github.com/uzh-rpg/flightmare/issues/175)

- the import from `rpg_baselines.common` seems to fail without the extra packages added to the cmake file, see this [issue](https://github.com/uzh-rpg/flightmare/issues/93)

If there's any other docs or PR etiquette I'm missing, please do let me know and I'll fix ASAP.